### PR TITLE
Quick hack to add VR support to these shaders

### DIFF
--- a/Packages/jp.keijiro.klak.hap/Resources/Hap1.shader
+++ b/Packages/jp.keijiro.klak.hap/Resources/Hap1.shader
@@ -20,6 +20,7 @@ Shader "Klak/HAP"
     {
         float4 position : SV_Position;
         float2 texcoord : TEXCOORD;
+        UNITY_VERTEX_OUTPUT_STEREO
     };
 
     sampler2D _MainTex;
@@ -29,6 +30,7 @@ Shader "Klak/HAP"
     {
         UNITY_SETUP_INSTANCE_ID(input);
         Varyings output;
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
         output.position = UnityObjectToClipPos(input.position);
         output.texcoord = TRANSFORM_TEX(input.texcoord, _MainTex);
         output.texcoord.y = 1 - output.texcoord.y;

--- a/Packages/jp.keijiro.klak.hap/Resources/Hap5.shader
+++ b/Packages/jp.keijiro.klak.hap/Resources/Hap5.shader
@@ -20,6 +20,7 @@ Shader "Klak/HAP Alpha"
     {
         float4 position : SV_Position;
         float2 texcoord : TEXCOORD;
+        UNITY_VERTEX_OUTPUT_STEREO
     };
 
     sampler2D _MainTex;
@@ -29,6 +30,7 @@ Shader "Klak/HAP Alpha"
     {
         UNITY_SETUP_INSTANCE_ID(input);
         Varyings output;
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
         output.position = UnityObjectToClipPos(input.position);
         output.texcoord = TRANSFORM_TEX(input.texcoord, _MainTex);
         output.texcoord.y = 1 - output.texcoord.y;

--- a/Packages/jp.keijiro.klak.hap/Resources/HapY.shader
+++ b/Packages/jp.keijiro.klak.hap/Resources/HapY.shader
@@ -20,6 +20,7 @@ Shader "Klak/HAP Q"
     {
         float4 position : SV_Position;
         float2 texcoord : TEXCOORD;
+        UNITY_VERTEX_OUTPUT_STEREO
     };
 
     sampler2D _MainTex;
@@ -43,6 +44,7 @@ Shader "Klak/HAP Q"
     {
         UNITY_SETUP_INSTANCE_ID(input);
         Varyings output;
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
         output.position = UnityObjectToClipPos(input.position);
         output.texcoord = TRANSFORM_TEX(input.texcoord, _MainTex);
         output.texcoord.y = 1 - output.texcoord.y;


### PR DESCRIPTION
When using the Klak/HAP shaders (HAP / HAP Alpha / HAP Q) within HTV VIVE headsets, only the screen from left eye is rendered. I looked up the Unity UI-Default shader and apply a quick hack so that these shaders work with VR.